### PR TITLE
Four dimensional array implementation that uses one single array

### DIFF
--- a/src/niftijio/Example.java
+++ b/src/niftijio/Example.java
@@ -2,7 +2,6 @@ package niftijio;
 
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.io.File;
 
 public class Example
 {
@@ -29,7 +28,7 @@ public class Example
                     for (int k = 0; k < nz; k++)
                         for (int j = 0; j < ny; j++)
                             for (int i = 0; i < nx; i++)
-                                volume.data[i][j][k][d] = count++;
+                                volume.data.set(i,j,k,d,count++);
                 volume.write("example.nii.gz");
             }
             else
@@ -62,7 +61,7 @@ public class Example
                         for (int k = 0; k < nz; k++)
                             for (int j = 0; j < ny; j++)
                                 for (int i = 0; i < nx; i++)
-                                    out.println(volume.data[i][j][k][d]);
+                                    out.println(volume.data.get(i,j,k,d));
 
                     out.println();
                     out.close();

--- a/src/niftijio/FourDimensionalArray.java
+++ b/src/niftijio/FourDimensionalArray.java
@@ -1,7 +1,15 @@
 package niftijio;
 
-/**
- * Created by bouabene on 8/25/15.
+/* Four-dimensional array implementation that avoids using java's multi-dimensional arrays.
+        * <p/>
+        * For very large images, java's multi-dimensional arrays cause too much overhead and eventually
+        * result in either heap or garbage collection issues. This implementation uses one single large array
+        * while providing a 4D access interface.
+        *
+        * Method names should be self-explanatory.
+        * @author Ghazi Bouabene, University of Basel, Switzerland
+        *
+        *
  */
 public class FourDimensionalArray {
 

--- a/src/niftijio/FourDimensionalArray.java
+++ b/src/niftijio/FourDimensionalArray.java
@@ -1,0 +1,49 @@
+package niftijio;
+
+/**
+ * Created by bouabene on 8/25/15.
+ */
+public class FourDimensionalArray {
+
+    private double[] data;
+    private int nx, ny, nz, dim;
+
+    public FourDimensionalArray(int nx, int ny, int nz, int dim) {
+        this.nx = nx;
+        this.ny = ny;
+        this.nz = nz;
+        this.dim = dim;
+        this.data = new double[nx * ny * nz * dim];
+    }
+
+    public FourDimensionalArray(double[][][][] array) {
+        int nx = array.length;
+        int ny = array[0].length;
+        int nz = array[0][0].length;
+        int dim = array[0][0][0].length;
+
+        this.data = new double[nx * ny * nz * dim];
+
+        for (int d = 0; d < dim; d++)
+            for (int k = 0; k < nz; k++)
+                for (int j = 0; j < ny; j++)
+                    for (int i = 0; i < nx; i++) {
+                        set(i,j,k,d, array[i][j][k][d]);
+                    }
+    }
+
+    public double get(int x, int y, int z, int d) {
+        int idx = d * (nx * ny * nz) + z * (nx * ny) + y * nx + x;
+        return data[idx];
+    }
+
+    public void set(int x, int y, int z, int d, double val) {
+        int idx = d * (nx * ny * nz) + z * (nx * ny) + y * nx + x;
+        data[idx] = val;
+    }
+
+    public int sizeX() {return nx;}
+    public int sizeY() {return ny;}
+    public int sizeZ() {return nz;}
+    public int dimension() {return dim;}
+}

--- a/src/niftijio/NiftiVolume.java
+++ b/src/niftijio/NiftiVolume.java
@@ -16,12 +16,12 @@ import java.util.zip.GZIPOutputStream;
 public class NiftiVolume
 {
     public NiftiHeader header;
-    public double[][][][] data;
+    public FourDimensionalArray data;
 
     public NiftiVolume(int nx, int ny, int nz, int dim)
     {
         this.header = new NiftiHeader(nx, ny, nz, dim);
-        this.data = new double[nx][ny][nz][dim];
+        this.data = new FourDimensionalArray(nx,ny,nz,dim);
     }
 
     public NiftiVolume(NiftiHeader hdr)
@@ -38,18 +38,12 @@ public class NiftiVolume
         if (dim == 0)
             dim = 1;
 
-        this.data = new double[nx][ny][nz][dim];
+        this.data = new FourDimensionalArray(nx,ny,nz,dim);
     }
 
     public NiftiVolume(double[][][][] data)
     {
-        int nx = data.length;
-        int ny = data[0].length;
-        int nz = data[0][0].length;
-        int dim = data[0][0][0].length;
-
-        this.header = new NiftiHeader(nx, ny, nz, dim);
-        this.data = data;
+        this.data = new FourDimensionalArray(data);
     }
 
     public static NiftiVolume read(String filename) throws IOException
@@ -145,7 +139,7 @@ public class NiftiVolume
                             throw new IOException("Sorry, cannot yet read nifti-1 datatype " + NiftiHeader.decodeDatatype(hdr.datatype));
                         }
 
-                        out.data[i][j][k][d] = v;
+                        out.data.set(i,j,k,d,v);
                     }
         }
 
@@ -180,7 +174,7 @@ public class NiftiVolume
                 for (int j = 0; j < ny; j++)
                     for (int i = 0; i < nx; i++)
                     {
-                        double v = this.data[i][j][k][d];
+                        double v = this.data.get(i,j,k,d);
 
                         switch (hdr.datatype)
                         {


### PR DESCRIPTION
Hi Cabeen,

We really like your library at our lab and use it a lot for our image IO in Scalismo (https://github.com/unibas-gravis/scalismo)

The change I submit is related to heavy load when reading a bit larger images. Typically, a call like 
new NiftiVolume(393, 541,1923, 1)  would either exceed the allocated heap size, or would run forever before triggering a "OutOfMemoryError: GC overhead limit exceeded".

This is due to the overhead introduced by java's multi-dimensional arrays that end up allocating much more than what is needed. 

My proposed solution below is to use one single large array with an interface similar to the multi-dimensional one. I already adapted the rest of the code to use the new class.

I tested it by reading and writing images and comparing. Works correctly, including for large images that caused the initial trouble.

Hope this helps,
Ghazi
